### PR TITLE
chore: this change makes build failing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1347,6 +1347,47 @@
           "style": "scss"
         }
       }
+    },
+    "demos-layout": {
+      "projectType": "library",
+      "root": "libs/demos/layout",
+      "sourceRoot": "libs/demos/layout/src",
+      "prefix": "kikstart-ui",
+      "architect": {
+        "build": {
+          "builder": "@nrwl/angular:package",
+          "options": {
+            "tsConfig": "libs/demos/layout/tsconfig.lib.json",
+            "project": "libs/demos/layout/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "libs/demos/layout/tsconfig.lib.prod.json"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": ["libs/demos/layout/tsconfig.lib.json", "libs/demos/layout/tsconfig.spec.json"],
+            "exclude": ["**/node_modules/**", "!libs/demos/layout/**"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/demos/layout/jest.config.js",
+            "tsConfig": "libs/demos/layout/tsconfig.spec.json",
+            "passWithNoTests": true,
+            "setupFile": "libs/demos/layout/src/test-setup.ts"
+          }
+        }
+      },
+      "schematics": {
+        "@nrwl/angular:component": {
+          "style": "scss"
+        }
+      }
     }
   },
   "cli": {

--- a/nx.json
+++ b/nx.json
@@ -113,6 +113,9 @@
     },
     "ui-icon": {
       "tags": []
+    },
+    "demos-layout": {
+      "tags": []
     }
   }
 }


### PR DESCRIPTION
When adding the change in this PR, the build breaks like this:

```
> ng run demos-layout:build
Some of the project demos-layout's dependencies have not been built yet. Please build these libraries before:
- layout-console

Try: nx run demos-layout:build --with-deps

———————————————————————————————————————————————

>  NX   ERROR  Running target "build" failed

  Failed projects:

  - demos-layout
  - demo

  You can isolate the above projects by passing: --only-failed
```

Running the suggested command `nx run demos-layout:build --with-deps` does not fix it:

```
$ nx run demos-layout:build --with-deps

>  NX  Running target build for project demos-layout and its 10 deps.

———————————————————————————————————————————————

> ng run demos-layout:build
Some of the project demos-layout's dependencies have not been built yet. Please build these libraries before:
- layout-console

Try: nx run demos-layout:build --with-deps

———————————————————————————————————————————————

>  NX   ERROR  Running target "build" failed

  Failed projects:

  - demos-layout

```

And it goes circular from here:


```

$ nx build layout-console --with-deps

> ng run layout-console:build

>  NX   NOTE  Cached Output:

Building Angular Package
******************************************************************************
It is not recommended to publish Ivy libraries to NPM repositories.
Read more here: https://v9.angular.io/guide/ivy#maintaining-library-compatibility
******************************************************************************

------------------------------------------------------------------------------
Building entry point '@kikstart-ui/layout-console'
------------------------------------------------------------------------------
Compiling TypeScript sources through ngc
Bundling to FESM2015
Bundling to FESM5
Bundling to UMD
Minifying UMD bundle
Writing package metadata
Built @kikstart-ui/layout-console

------------------------------------------------------------------------------
Built Angular Package
 - from: /Users/beeman/kikstart-ui/libs/layout/console
 - to:   /Users/beeman/kikstart-ui/dist/libs/layout-console
------------------------------------------------------------------------------

———————————————————————————————————————————————

>  NX   SUCCESS  Running target "build" succeeded

  Nx read the output from cache instead of running the command for 1 out of 1 projects.

$ nx run demos-layout:build --with-deps

>  NX  Running target build for project demos-layout and its 10 deps.

———————————————————————————————————————————————

> ng run demos-layout:build
Some of the project demos-layout's dependencies have not been built yet. Please build these libraries before:
- layout-console

Try: nx run demos-layout:build --with-deps

———————————————————————————————————————————————

>  NX   ERROR  Running target "build" failed

  Failed projects:

  - demos-layout

```